### PR TITLE
サービスtypeとURLを追加 #31

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,10 +3,9 @@
 <mat-sidenav-container>
   <mat-sidenav
     #sidenav
-    mode="over"
     [opened]="opened$ | async"
     fixedInViewport
-    [fixedTopGap]="105"
+    [fixedTopGap]="89"
     class="sidenav"
   >
     <mat-nav-list>
@@ -16,7 +15,11 @@
       <a mat-list-item routerLink="/">
         <mat-icon class="mat-icon">event</mat-icon>イベント</a
       >
+      <a mat-list-item routerLink="/">
+        <mat-icon class="mat-icon">history</mat-icon>履歴</a
+      >
       <mat-divider class="divider"></mat-divider>
+      <h3 mat-subheader>カテゴリー</h3>
       <a mat-list-item routerLink="/">
         <mat-icon class="mat-icon">code</mat-icon>プログラミング</a
       >
@@ -30,19 +33,16 @@
         <mat-icon class="mat-icon">directions_run</mat-icon>スポーツ</a
       >
       <a mat-list-item routerLink="/">
-        <mat-icon class="mat-icon">fitness_center</mat-icon>筋トレ</a
-      >
-      <a mat-list-item routerLink="/">
         <mat-icon class="mat-icon">music_note</mat-icon>ダンス</a
       >
       <a mat-list-item routerLink="/">
-        <mat-icon class="mat-icon">accessibility</mat-icon>ダイエット</a
+        <mat-icon class="mat-icon">accessibility</mat-icon>美容</a
       >
       <a mat-list-item routerLink="/">
         <mat-icon class="mat-icon">local_dining</mat-icon>料理</a
       >
       <a mat-list-item routerLink="/">
-        <mat-icon class="mat-icon">event_seat</mat-icon>インテリア</a
+        <mat-icon class="mat-icon">medical_services</mat-icon>医療</a
       >
       <a mat-list-item routerLink="/">
         <mat-icon class="mat-icon">emoji_objects</mat-icon>モノづくり</a
@@ -50,15 +50,19 @@
       <a mat-list-item routerLink="/">
         <mat-icon class="mat-icon">graphic_eq</mat-icon>音楽</a
       >
+      <a mat-list-item routerLink="/">
+        <mat-icon class="mat-icon">more_horiz</mat-icon>その他</a
+      >
+
       <mat-divider class="divider"></mat-divider>
       <a mat-list-item routerLink="/">
-        <mat-icon class="mat-icon">people</mat-icon>フォロー</a
+        <mat-icon class="mat-icon">people</mat-icon>参加済</a
       >
       <a mat-list-item routerLink="/">
-        <mat-icon class="mat-icon">favorite</mat-icon>チップ</a
+        <mat-icon class="mat-icon">textsms</mat-icon>メッセージ</a
       >
       <a mat-list-item routerLink="/">
-        <mat-icon class="mat-icon">event</mat-icon>イベント</a
+        <mat-icon class="mat-icon">settings</mat-icon>設定</a
       >
       <mat-divider class="divider"></mat-divider>
     </mat-nav-list>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -4,7 +4,7 @@
 
 .mat-icon {
   margin: 0 24px 0 16px;
-  opacity: .8;
+  opacity: 0.8;
 }
 
 .divider {
@@ -12,11 +12,19 @@
 }
 
 .footer {
-  margin: 16px;
-  text-align: center;
+  margin: 24px;
   font-weight: 300;
-  color: rgba(#ffffff, .8);
+  color: rgba(#ffffff, 0.8);
   &__copy {
-  color: rgba(#ffffff, .38);
+    color: rgba(#ffffff, 0.38);
+    margin-top: 24px;
   }
+}
+
+mat-nav-list a {
+  margin-right: 16px;
+}
+
+mat-nav-list h3 {
+  margin-left: 16px;
 }

--- a/src/app/article-detail/article/article.component.html
+++ b/src/app/article-detail/article/article.component.html
@@ -111,7 +111,7 @@
           <h4 class="feature__title">
             {{ article.featureTitle1 }}
           </h4>
-          <p class="feature__p">
+          <p class="feature__description">
             {{ article.featureBody1 }}
           </p>
         </div>
@@ -123,7 +123,7 @@
           <h4 class="feature__title">
             {{ article.featureTitle2 }}
           </h4>
-          <p class="feature__p">
+          <p class="feature__description">
             {{ article.featureBody2 }}
           </p>
         </div>

--- a/src/app/article-detail/article/article.component.html
+++ b/src/app/article-detail/article/article.component.html
@@ -106,16 +106,26 @@
       <h3 class="feature-section__title">サービスの特徴</h3>
       <div class="feature">
         <img class="feature__image" [src]="article.image1" alt="" />
-        <p class="feature__text">
-          {{ article.feature }}
-        </p>
+        <div class="feature__body">
+          <h4 class="feature__title">
+            {{ article.featureTitle1 }}
+          </h4>
+          <p class="feature__p">
+            {{ article.featureBody1 }}
+          </p>
+        </div>
       </div>
 
       <div class="feature">
         <img class="feature__image" [src]="article.image2" alt="" />
-        <p class="feature__text">
-          {{ article.feature }}
-        </p>
+        <div class="feature__body">
+          <h4 class="feature__title">
+            {{ article.featureTitle2 }}
+          </h4>
+          <p class="feature__p">
+            {{ article.featureBody2 }}
+          </p>
+        </div>
       </div>
     </div>
 

--- a/src/app/article-detail/article/article.component.html
+++ b/src/app/article-detail/article/article.component.html
@@ -5,7 +5,6 @@
         <img [src]="article.thumbnailURL" alt="" />
       </figure>
       <button mat-flat-button color="primary">
-        <mat-icon class="hero__category-icon">code</mat-icon>
         <p class="hero__category-text">{{ article.category }}</p>
       </button>
 
@@ -18,14 +17,16 @@
           <img [src]="article.logo" alt="" />
         </figure>
         <h2 class="hero__title">
-          {{ article.name }}
+          <a href="{{ article.serviceURL }}" target="_blank">{{
+            article.name
+          }}</a>
         </h2>
       </div>
     </div>
 
     <div class="users-section">
       <div class="users">
-        <h3 class="users__title">CAMPのユーザー</h3>
+        <h3 class="users__title">{{ article.name }}のユーザー</h3>
         <button class="users__button">もっと見る</button>
       </div>
 
@@ -136,6 +137,12 @@
           {{ article.plan }}
         </p>
       </div>
+    </div>
+
+    <div class="link-button">
+      <a mat-flat-button href="{{ article.serviceURL }}" target="_blank">
+        {{ article.name }} を見てみる
+      </a>
     </div>
   </div>
   <ng-template #blank>

--- a/src/app/article-detail/article/article.component.scss
+++ b/src/app/article-detail/article/article.component.scss
@@ -108,7 +108,7 @@ mat-tab-group {
   &__title {
     margin: 8px 16px;
   }
-  &__p {
+  &__description {
     margin: 8px 16px;
     font-size: 14px;
   }

--- a/src/app/article-detail/article/article.component.scss
+++ b/src/app/article-detail/article/article.component.scss
@@ -108,7 +108,11 @@ mat-tab-group {
     height: 100px;
     border-radius: 20px;
   }
-  &__text {
-    margin: 16px;
+  &__title {
+    margin: 8px 16px;
+  }
+  &__p {
+    margin: 8px 16px;
+    font-size: 14px;
   }
 }

--- a/src/app/article-detail/article/article.component.scss
+++ b/src/app/article-detail/article/article.component.scss
@@ -1,6 +1,6 @@
 section {
   background-color: rgba(38, 50, 56);
-  padding: 48px 0;
+  padding: 48px 24px;
 }
 
 .article {
@@ -15,10 +15,6 @@ section {
   margin-bottom: 24px;
   &__thumbnail {
     max-width: 100%;
-  }
-  &__category-icon {
-    margin-right: 8px;
-    opacity: 0.6;
   }
   &__category-text {
     opacity: 0.6;
@@ -37,6 +33,7 @@ section {
 
 h1 {
   font-size: 20px;
+  margin-bottom: 8px;
 }
 h2 {
   font-size: 20px;
@@ -115,4 +112,11 @@ mat-tab-group {
     margin: 8px 16px;
     font-size: 14px;
   }
+}
+
+.link-button a {
+  width: 100%;
+  background-color: #2aa1f1;
+  border-radius: 25px;
+  margin: 48px auto;
 }

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -13,6 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTableModule } from '@angular/material/table';
+import { MatRadioModule } from '@angular/material/radio';
 
 @NgModule({
   declarations: [EditorComponent],
@@ -30,6 +31,7 @@ import { MatTableModule } from '@angular/material/table';
     MatSlideToggleModule,
     MatTabsModule,
     MatTableModule,
+    MatRadioModule,
   ],
 })
 export class EditorModule {}

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -71,7 +71,16 @@
               ファイルが選択されていません
             </p>
           </div>
-          <mat-divider></mat-divider>
+
+          <h2>タイプ</h2>
+          <mat-radio-group
+            color="primary"
+            aria-label="Select an option"
+            formControlName="type"
+          >
+            <mat-radio-button value="1">スクール</mat-radio-button>
+            <mat-radio-button value="2">オンラインサロン</mat-radio-button>
+          </mat-radio-group>
 
           <h2>カテゴリー</h2>
           <mat-form-field>

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -78,8 +78,8 @@
             aria-label="Select an option"
             formControlName="type"
           >
-            <mat-radio-button [value]="1">スクール</mat-radio-button>
-            <mat-radio-button [value]="2">オンラインサロン</mat-radio-button>
+            <mat-radio-button value="school">スクール</mat-radio-button>
+            <mat-radio-button value="salon">オンラインサロン</mat-radio-button>
           </mat-radio-group>
 
           <h2>カテゴリー</h2>
@@ -127,12 +127,7 @@
 
           <h3>タイトル</h3>
           <mat-form-field appearance="outline">
-            <input
-              matInput
-              formControlName="featureTitle1"
-              #featureTitle1
-              required
-            />
+            <input matInput formControlName="featureTitle1" required />
             <mat-hint align="end"
               >{{ featureTitle1.value.length }} / 50文字</mat-hint
             >
@@ -142,7 +137,6 @@
             <textarea
               matInput
               formControlName="featureBody1"
-              #featureBody1
               matTextareaAutosize
               [matAutosizeMinRows]="4"
             ></textarea>
@@ -181,12 +175,7 @@
 
           <h3>タイトル</h3>
           <mat-form-field appearance="outline">
-            <input
-              matInput
-              formControlName="featureTitle2"
-              #featureTitle2
-              required
-            />
+            <input matInput formControlName="featureTitle2" required />
             <mat-hint align="end"
               >{{ featureTitle2.value.length }} / 50文字</mat-hint
             >
@@ -196,7 +185,6 @@
             <textarea
               matInput
               formControlName="featureBody2"
-              #featureBody2
               matTextareaAutosize
               [matAutosizeMinRows]="4"
             ></textarea>

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -4,6 +4,13 @@
     <form [formGroup]="form" (ngSubmit)="submit()">
       <div class="edit-column">
         <div class="edit-column__left">
+          <h2>記事タイトル</h2>
+          <mat-form-field appearance="outline">
+            <input matInput formControlName="title" #title required />
+            <mat-hint align="end">{{ title.value.length }} / 150文字</mat-hint>
+          </mat-form-field>
+          <mat-divider></mat-divider>
+
           <h2>メイン画像</h2>
           <div class="main-img">
             <img *ngIf="srcs?.thumbnailURL" [src]="srcs.thumbnailURL" alt="" />
@@ -35,7 +42,7 @@
           <h2>サービス名</h2>
           <mat-form-field appearance="outline">
             <input matInput formControlName="name" #name required />
-            <mat-hint align="end">{{ name.value.length }} / 100文字</mat-hint>
+            <mat-hint align="end">{{ name.value.length }} / 50文字</mat-hint>
           </mat-form-field>
 
           <h2>サービスロゴ</h2>
@@ -64,6 +71,7 @@
               ファイルが選択されていません
             </p>
           </div>
+          <mat-divider></mat-divider>
 
           <h2>カテゴリー</h2>
           <mat-form-field>
@@ -80,32 +88,12 @@
         </div>
 
         <div class="edit-column__center">
-          <h2>記事タイトル</h2>
-          <mat-form-field appearance="outline">
-            <input matInput formControlName="title" #title required />
-            <mat-hint align="end">{{ title.value.length }} / 100文字</mat-hint>
-          </mat-form-field>
-
           <h2>サービスの特徴</h2>
-          <mat-form-field appearance="outline" class="feature">
-            <textarea
-              matInput
-              formControlName="feature"
-              #feature
-              matTextareaAutosize
-              [matAutosizeMinRows]="10"
-            ></textarea>
-            <mat-hint align="end"
-              >{{ feature.value.length }} / 400文字</mat-hint
-            >
-          </mat-form-field>
-          <mat-divider></mat-divider>
-
-          <h2>イメージ画像1</h2>
+          <h3>イメージ画像1</h3>
           <div class="sub-img">
             <img *ngIf="srcs?.image1" [src]="srcs.image1" alt="" />
             <p class="note" *ngIf="!srcs.image1">
-              ※ 640px x 360px
+              ※ 800px x 800px
             </p>
             <input
               type="file"
@@ -128,11 +116,38 @@
             </p>
           </div>
 
-          <h2>イメージ画像2</h2>
+          <h3>タイトル</h3>
+          <mat-form-field appearance="outline">
+            <input
+              matInput
+              formControlName="featureTitle1"
+              #featureTitle1
+              required
+            />
+            <mat-hint align="end"
+              >{{ featureTitle1.value.length }} / 50文字</mat-hint
+            >
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="feature">
+            <textarea
+              matInput
+              formControlName="featureBody1"
+              #featureBody1
+              matTextareaAutosize
+              [matAutosizeMinRows]="4"
+            ></textarea>
+            <mat-hint align="end"
+              >{{ featureBody1.value.length }} / 200文字</mat-hint
+            >
+          </mat-form-field>
+          <mat-divider></mat-divider>
+
+          <h3>イメージ画像2</h3>
           <div class="sub-img">
             <img *ngIf="srcs?.image2" [src]="srcs.image2" alt="" />
             <p class="note" *ngIf="!srcs.image2">
-              ※ 640px x 360px
+              ※ 800px x 800px
             </p>
             <input
               type="file"
@@ -154,6 +169,32 @@
               ファイルが選択されていません
             </p>
           </div>
+
+          <h3>タイトル</h3>
+          <mat-form-field appearance="outline">
+            <input
+              matInput
+              formControlName="featureTitle2"
+              #featureTitle2
+              required
+            />
+            <mat-hint align="end"
+              >{{ featureTitle2.value.length }} / 50文字</mat-hint
+            >
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="feature">
+            <textarea
+              matInput
+              formControlName="featureBody2"
+              #featureBody2
+              matTextareaAutosize
+              [matAutosizeMinRows]="4"
+            ></textarea>
+            <mat-hint align="end"
+              >{{ featureBody2.value.length }} / 200文字</mat-hint
+            >
+          </mat-form-field>
           <mat-divider></mat-divider>
         </div>
 

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -78,8 +78,8 @@
             aria-label="Select an option"
             formControlName="type"
           >
-            <mat-radio-button value="1">スクール</mat-radio-button>
-            <mat-radio-button value="2">オンラインサロン</mat-radio-button>
+            <mat-radio-button [value]="1">スクール</mat-radio-button>
+            <mat-radio-button [value]="2">オンラインサロン</mat-radio-button>
           </mat-radio-group>
 
           <h2>カテゴリー</h2>

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -210,6 +210,11 @@
             ></textarea>
             <mat-hint align="end">{{ plan.value.length }} / 400文字</mat-hint>
           </mat-form-field>
+
+          <h2>サービスURL</h2>
+          <mat-form-field appearance="outline">
+            <input matInput formControlName="serviceURL" required />
+          </mat-form-field>
           <mat-slide-toggle color="primary">非公開 / 公開</mat-slide-toggle>
 
           <button

--- a/src/app/editor/editor/editor.component.scss
+++ b/src/app/editor/editor/editor.component.scss
@@ -29,8 +29,8 @@
 }
 .sub-img {
   position: relative;
-  width: 160px;
-  height: 90px;
+  width: 100px;
+  height: 100px;
   border: dashed 1px;
   margin: 0 auto;
 }
@@ -43,6 +43,15 @@
 
 h2 {
   font-size: 18px;
+  font-weight: 500;
+  background: rgba(rgb(36, 36, 36), 0.6);
+  padding-left: 8px;
+  margin-bottom: 16px;
+  border-left: solid 2px #c2185b;
+}
+
+h3 {
+  font-size: 14px;
   font-weight: 500;
 }
 

--- a/src/app/editor/editor/editor.component.scss
+++ b/src/app/editor/editor/editor.component.scss
@@ -48,6 +48,7 @@ h2 {
   padding-left: 8px;
   margin-bottom: 16px;
   border-left: solid 2px #c2185b;
+  margin-top: 16px;
 }
 
 h3 {
@@ -65,6 +66,10 @@ mat-divider {
 
 mat-slide-toggle {
   float: right;
+}
+
+mat-radio-button {
+  margin-right: 16px;
 }
 
 .note {

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -106,8 +106,12 @@ export class EditorComponent implements OnInit {
     return this.form.get('plan') as FormControl;
   }
 
-  get seviceURL(): FormControl {
+  get serviceURL(): FormControl {
     return this.form.get('serviceURL') as FormControl;
+  }
+
+  get type(): FormControl {
+    return this.form.get('type') as FormControl;
   }
 
   ngOnInit(): void {}
@@ -137,6 +141,7 @@ export class EditorComponent implements OnInit {
           featureBody2: formData.featureBody2,
           plan: formData.plan,
           serviceURL: formData.serviceURL,
+          type: formData.type,
         },
         this.images
       )

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/sevices/article.service';
 import { AngularFirestore } from '@angular/fire/firestore';
@@ -50,10 +50,13 @@ export class EditorComponent implements OnInit {
   ];
 
   form = this.fb.group({
-    name: ['', [Validators.required, Validators.maxLength(100)]],
+    name: ['', [Validators.required, Validators.maxLength(50)]],
     categorys: ['', [Validators.required]],
-    title: ['', [Validators.required, Validators.maxLength(100)]],
-    feature: ['', [Validators.required, Validators.maxLength(400)]],
+    title: ['', [Validators.required, Validators.maxLength(150)]],
+    featureTitle1: ['', [Validators.required, Validators.maxLength(50)]],
+    featureBody1: ['', [Validators.required, Validators.maxLength(200)]],
+    featureTitle2: ['', [Validators.required, Validators.maxLength(50)]],
+    featureBody2: ['', [Validators.required, Validators.maxLength(200)]],
     plan: ['', [Validators.required, Validators.maxLength(400)]],
   });
 
@@ -85,8 +88,17 @@ export class EditorComponent implements OnInit {
     return this.form.get('title') as FormControl;
   }
 
-  get feature(): FormControl {
-    return this.form.get('feature') as FormControl;
+  get featureTitle1(): FormControl {
+    return this.form.get('featureTitle1') as FormControl;
+  }
+  get featureBody1(): FormControl {
+    return this.form.get('featureBody1') as FormControl;
+  }
+  get featureTitle2(): FormControl {
+    return this.form.get('featureTitle2') as FormControl;
+  }
+  get featureBody2(): FormControl {
+    return this.form.get('featureBody2') as FormControl;
   }
 
   get plan(): FormControl {
@@ -114,7 +126,10 @@ export class EditorComponent implements OnInit {
           title: formData.title,
           category: formData.categorys,
           createdAt: firestore.Timestamp.now(),
-          feature: formData.feature,
+          featureTitle1: formData.featureTitle1,
+          featureBody1: formData.featureBody1,
+          featureTitle2: formData.featureTitle2,
+          featureBody2: formData.featureBody2,
           plan: formData.plan,
         },
         this.images

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -59,6 +59,7 @@ export class EditorComponent implements OnInit {
     featureBody2: ['', [Validators.required, Validators.maxLength(200)]],
     plan: ['', [Validators.required, Validators.maxLength(400)]],
     serviceURL: [''],
+    type: [''],
   });
 
   constructor(

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -58,6 +58,7 @@ export class EditorComponent implements OnInit {
     featureTitle2: ['', [Validators.required, Validators.maxLength(50)]],
     featureBody2: ['', [Validators.required, Validators.maxLength(200)]],
     plan: ['', [Validators.required, Validators.maxLength(400)]],
+    serviceURL: [''],
   });
 
   constructor(
@@ -105,6 +106,10 @@ export class EditorComponent implements OnInit {
     return this.form.get('plan') as FormControl;
   }
 
+  get seviceURL(): FormControl {
+    return this.form.get('serviceURL') as FormControl;
+  }
+
   ngOnInit(): void {}
 
   // エディター画面に画像をセットするメソッド
@@ -131,6 +136,7 @@ export class EditorComponent implements OnInit {
           featureTitle2: formData.featureTitle2,
           featureBody2: formData.featureBody2,
           plan: formData.plan,
+          serviceURL: formData.serviceURL,
         },
         this.images
       )

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -11,7 +11,7 @@ export interface Article {
   featureBody2: string;
   plan: string;
   serviceURL: string;
-  type: number;
+  type: 'school' | 'salon' | null;
   id: string;
   thumbnailURL: string;
   logo: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -5,7 +5,10 @@ export interface Article {
   title: string;
   category: string;
   createdAt: firestore.Timestamp;
-  feature: string;
+  featureTitle1: string;
+  featureBody1: string;
+  featureTitle2: string;
+  featureBody2: string;
   plan: string;
   id: string;
   thumbnailURL: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -10,6 +10,7 @@ export interface Article {
   featureTitle2: string;
   featureBody2: string;
   plan: string;
+  serviceURL: string;
   id: string;
   thumbnailURL: string;
   logo: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -11,6 +11,7 @@ export interface Article {
   featureBody2: string;
   plan: string;
   serviceURL: string;
+  type: number;
   id: string;
   thumbnailURL: string;
   logo: string;


### PR DESCRIPTION
## Detail

記事詳細画面にURLのリンクを追加しました。加えて今後サロンとスクールを分けて表示するため、記事のインターフェイスにradioボタンでtypeを追加できるようにしました。

## Todo

- [x] Articleにtype追加
- [x] 記事詳細にserviceURLを追加
- [x] 各スタイル調整

## Image

以下2箇所をリンクにしました。
![image](https://user-images.githubusercontent.com/60227737/83718130-6b4cd700-a66f-11ea-9f4d-8ced24d03f8a.png)

![image](https://user-images.githubusercontent.com/60227737/83718173-83245b00-a66f-11ea-9584-e795930e94b4.png)
