### PR TITLE
管理画面内の記事一覧タブ追加 #77

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -76,10 +76,6 @@
   </mat-sidenav>
 
   <mat-sidenav-content>
-    <router-outlet>
-      <div class="loading" *ngIf="loading$ | async">
-        <mat-spinner></mat-spinner>
-      </div>
-    </router-outlet>
+    <router-outlet> </router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -76,7 +76,10 @@
   </mat-sidenav>
 
   <mat-sidenav-content>
-    <div class="loading" *ngIf="loading$ | async"></div>
-    <router-outlet></router-outlet>
+    <router-outlet>
+      <div class="loading" *ngIf="loading$ | async">
+        <mat-spinner></mat-spinner>
+      </div>
+    </router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -76,6 +76,7 @@
   </mat-sidenav>
 
   <mat-sidenav-content>
+    <div class="loading" *ngIf="loading$ | async"></div>
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -21,6 +21,12 @@
   }
 }
 
+.loading {
+  margin: 64px auto;
+  display: flex;
+  justify-content: center;
+}
+
 mat-nav-list a {
   margin-right: 16px;
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { DrawerService } from './services/drawer.service';
 import { Observable } from 'rxjs';
-import { LoadingService } from './services/loading.service';
 
 @Component({
   selector: 'app-root',
@@ -12,10 +11,6 @@ export class AppComponent {
   title = 'Players Hub';
 
   opened$: Observable<boolean> = this.drawerservice.isOpen$;
-  loading$ = this.loadingService.loading$;
 
-  constructor(
-    private drawerservice: DrawerService,
-    private loadingService: LoadingService
-  ) {}
+  constructor(private drawerservice: DrawerService) {}
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { DrawerService } from './services/drawer.service';
 import { Observable } from 'rxjs';
+import { LoadingService } from './services/loading.service';
 
 @Component({
   selector: 'app-root',
@@ -8,8 +9,13 @@ import { Observable } from 'rxjs';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
-  title = 'school-potal';
-  opened$: Observable<boolean> = this.drawerservice.isOpen$;
+  title = 'Players Hub';
 
-  constructor(private drawerservice: DrawerService) {}
+  opened$: Observable<boolean> = this.drawerservice.isOpen$;
+  loading$ = this.loadingService.loading$;
+
+  constructor(
+    private drawerservice: DrawerService,
+    private loadingService: LoadingService
+  ) {}
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { CommonModule } from '@angular/common';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { StudentsDialogComponent } from './article-detail/students-dialog/students-dialog.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, NavigationComponent],
@@ -48,6 +49,7 @@ import { StudentsDialogComponent } from './article-detail/students-dialog/studen
     MatListModule,
     MatDividerModule,
     MatSnackBarModule,
+    MatProgressSpinnerModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/editor/editor-article-list/editor-article-list.component.html
+++ b/src/app/editor/editor-article-list/editor-article-list.component.html
@@ -1,1 +1,47 @@
-<p>editor-article-list works!</p>
+<div class="list-container">
+  <table mat-table [dataSource]="dataSource">
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>状態</th>
+      <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="id">
+      <th mat-header-cell *matHeaderCellDef>ID</th>
+      <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>サービス名</th>
+      <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="createdAt">
+      <th mat-header-cell *matHeaderCellDef>作成日</th>
+      <td mat-cell *matCellDef="let element">{{ element.createdAt }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="category">
+      <th mat-header-cell *matHeaderCellDef>カテゴリー</th>
+      <td mat-cell *matCellDef="let element">
+        {{ element.category }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="menu">
+      <th mat-header-cell *matHeaderCellDef>操作メニュー</th>
+      <td mat-cell *matCellDef="let element">
+        {{ element.category }}
+      </td>
+    </ng-container>
+
+    <mat-text-column name="menu"></mat-text-column>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  </table>
+
+  <mat-paginator
+    [pageSizeOptions]="[5, 10, 20]"
+    showFirstLastButtons
+  ></mat-paginator>
+</div>

--- a/src/app/editor/editor-article-list/editor-article-list.component.html
+++ b/src/app/editor/editor-article-list/editor-article-list.component.html
@@ -1,8 +1,17 @@
 <div class="list-container">
   <table mat-table [dataSource]="dataSource">
+    <ng-container matColumnDef="number">
+      <th mat-header-cell *matHeaderCellDef>No.</th>
+      <td mat-cell *matCellDef="let element; index as i">
+        {{ i + 1 }}
+      </td>
+    </ng-container>
+
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>状態</th>
-      <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+      <td mat-cell *matCellDef="let element">
+        ○
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="id">
@@ -17,7 +26,16 @@
 
     <ng-container matColumnDef="createdAt">
       <th mat-header-cell *matHeaderCellDef>作成日</th>
-      <td mat-cell *matCellDef="let element">{{ element.createdAt }}</td>
+      <td mat-cell *matCellDef="let element">
+        {{ element.createdAt.toDate() | date: 'yyyy/MM/dd HH:mm' }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="updatedAt">
+      <th mat-header-cell *matHeaderCellDef>更新日</th>
+      <td mat-cell *matCellDef="let element">
+        {{ element.createdAt.toDate() | date: 'yyyy/MM/dd HH:mm' }}
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="category">
@@ -30,8 +48,8 @@
     <ng-container matColumnDef="menu">
       <th mat-header-cell *matHeaderCellDef>操作メニュー</th>
       <td mat-cell *matCellDef="let element">
-        <mat-icon>edit</mat-icon>
-        <mat-icon>delete</mat-icon>
+        <button mat-button><mat-icon>edit</mat-icon></button>
+        <button mat-button><mat-icon>delete</mat-icon></button>
       </td>
     </ng-container>
 
@@ -42,7 +60,7 @@
   </table>
 
   <mat-paginator
-    [pageSizeOptions]="[5, 10, 20]"
+    [pageSizeOptions]="[10, 20, 50]"
     showFirstLastButtons
   ></mat-paginator>
 </div>

--- a/src/app/editor/editor-article-list/editor-article-list.component.html
+++ b/src/app/editor/editor-article-list/editor-article-list.component.html
@@ -1,0 +1,1 @@
+<p>editor-article-list works!</p>

--- a/src/app/editor/editor-article-list/editor-article-list.component.html
+++ b/src/app/editor/editor-article-list/editor-article-list.component.html
@@ -30,7 +30,8 @@
     <ng-container matColumnDef="menu">
       <th mat-header-cell *matHeaderCellDef>操作メニュー</th>
       <td mat-cell *matCellDef="let element">
-        {{ element.category }}
+        <mat-icon>edit</mat-icon>
+        <mat-icon>delete</mat-icon>
       </td>
     </ng-container>
 

--- a/src/app/editor/editor-article-list/editor-article-list.component.html
+++ b/src/app/editor/editor-article-list/editor-article-list.component.html
@@ -1,4 +1,4 @@
-<div class="list-container">
+<div class="list-container" *ngIf="dataSource; else loading">
   <table mat-table [dataSource]="dataSource">
     <ng-container matColumnDef="number">
       <th mat-header-cell *matHeaderCellDef>No.</th>
@@ -53,8 +53,6 @@
       </td>
     </ng-container>
 
-    <!-- <mat-text-column name="menu"></mat-text-column> -->
-
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>
@@ -64,3 +62,7 @@
     showFirstLastButtons
   ></mat-paginator>
 </div>
+
+<ng-template #loading class="spinner">
+  <mat-spinner></mat-spinner>
+</ng-template>

--- a/src/app/editor/editor-article-list/editor-article-list.component.html
+++ b/src/app/editor/editor-article-list/editor-article-list.component.html
@@ -34,7 +34,7 @@
       </td>
     </ng-container>
 
-    <mat-text-column name="menu"></mat-text-column>
+    <!-- <mat-text-column name="menu"></mat-text-column> -->
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>

--- a/src/app/editor/editor-article-list/editor-article-list.component.scss
+++ b/src/app/editor/editor-article-list/editor-article-list.component.scss
@@ -11,3 +11,7 @@ mat-paginator {
   width: 90%;
   margin: 0 auto 24px;
 }
+
+mat-icon {
+  margin-right: 16px;
+}

--- a/src/app/editor/editor-article-list/editor-article-list.component.scss
+++ b/src/app/editor/editor-article-list/editor-article-list.component.scss
@@ -1,0 +1,13 @@
+.list-container {
+  height: 100vh;
+}
+
+table {
+  width: 90%;
+  margin: 24px auto 0;
+}
+
+mat-paginator {
+  width: 90%;
+  margin: 0 auto 24px;
+}

--- a/src/app/editor/editor-article-list/editor-article-list.component.scss
+++ b/src/app/editor/editor-article-list/editor-article-list.component.scss
@@ -2,6 +2,10 @@
   height: 100vh;
 }
 
+mat-spinner {
+  margin: 64px auto;
+}
+
 table {
   width: 90%;
   margin: 24px auto 0;

--- a/src/app/editor/editor-article-list/editor-article-list.component.scss
+++ b/src/app/editor/editor-article-list/editor-article-list.component.scss
@@ -11,7 +11,3 @@ mat-paginator {
   width: 90%;
   margin: 0 auto 24px;
 }
-
-mat-icon {
-  margin-right: 16px;
-}

--- a/src/app/editor/editor-article-list/editor-article-list.component.spec.ts
+++ b/src/app/editor/editor-article-list/editor-article-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditorArticleListComponent } from './editor-article-list.component';
+
+describe('EditorArticleListComponent', () => {
+  let component: EditorArticleListComponent;
+  let fixture: ComponentFixture<EditorArticleListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorArticleListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorArticleListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor/editor-article-list/editor-article-list.component.ts
+++ b/src/app/editor/editor-article-list/editor-article-list.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-editor-article-list',
+  templateUrl: './editor-article-list.component.html',
+  styleUrls: ['./editor-article-list.component.scss'],
+})
+export class EditorArticleListComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/editor/editor-article-list/editor-article-list.component.ts
+++ b/src/app/editor/editor-article-list/editor-article-list.component.ts
@@ -6,6 +6,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { Article } from 'src/app/interfaces/article';
 import { tap } from 'rxjs/operators';
+import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
   selector: 'app-editor-article-list',
@@ -21,14 +22,19 @@ export class EditorArticleListComponent implements OnInit {
     'category',
     'menu',
   ];
-  dataSource = this.articleService.getArticles();
+  dataSource = this.articleService
+    .getArticles()
+    .pipe(tap(() => this.loadingService.toggleLoading(false)));
 
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
   constructor(
     private articleService: ArticleService,
-    private db: AngularFirestore
-  ) {}
+    private db: AngularFirestore,
+    private loadingService: LoadingService
+  ) {
+    this.loadingService.toggleLoading(true);
+  }
 
   ngOnInit() {
     this.dataSource.paginator = this.paginator;

--- a/src/app/editor/editor-article-list/editor-article-list.component.ts
+++ b/src/app/editor/editor-article-list/editor-article-list.component.ts
@@ -2,8 +2,6 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { ArticleService } from 'src/app/sevices/article.service';
-import { AngularFirestore } from '@angular/fire/firestore';
-import { Observable } from 'rxjs';
 import { Article } from 'src/app/interfaces/article';
 import { tap } from 'rxjs/operators';
 import { LoadingService } from 'src/app/services/loading.service';
@@ -15,28 +13,33 @@ import { LoadingService } from 'src/app/services/loading.service';
 })
 export class EditorArticleListComponent implements OnInit {
   displayedColumns: string[] = [
+    'number',
     'status',
     'id',
     'name',
     'createdAt',
+    'updatedAt',
     'category',
     'menu',
   ];
-  dataSource = this.articleService
-    .getArticles()
-    .pipe(tap(() => this.loadingService.toggleLoading(false)));
+  dataSource: MatTableDataSource<Article>;
 
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
   constructor(
     private articleService: ArticleService,
-    private db: AngularFirestore,
     private loadingService: LoadingService
   ) {
     this.loadingService.toggleLoading(true);
   }
 
   ngOnInit() {
-    this.dataSource.paginator = this.paginator;
+    this.articleService
+      .getArticles()
+      .pipe(tap(() => this.loadingService.toggleLoading(false)))
+      .subscribe((data) => {
+        this.dataSource = new MatTableDataSource<Article>(data);
+        this.dataSource.paginator = this.paginator;
+      });
   }
 }

--- a/src/app/editor/editor-article-list/editor-article-list.component.ts
+++ b/src/app/editor/editor-article-list/editor-article-list.component.ts
@@ -1,4 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { ArticleService } from 'src/app/sevices/article.service';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { Article } from 'src/app/interfaces/article';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-editor-article-list',
@@ -6,7 +13,24 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./editor-article-list.component.scss'],
 })
 export class EditorArticleListComponent implements OnInit {
-  constructor() {}
+  displayedColumns: string[] = [
+    'status',
+    'id',
+    'name',
+    'createdAt',
+    'category',
+    'menu',
+  ];
+  dataSource = this.articleService.getArticles();
 
-  ngOnInit(): void {}
+  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
+
+  constructor(
+    private articleService: ArticleService,
+    private db: AngularFirestore
+  ) {}
+
+  ngOnInit() {
+    this.dataSource.paginator = this.paginator;
+  }
 }

--- a/src/app/editor/editor-home/editor-home.component.html
+++ b/src/app/editor/editor-home/editor-home.component.html
@@ -12,4 +12,4 @@
   </a>
 </nav>
 
-<router-outlet> </router-outlet>
+<router-outlet></router-outlet>

--- a/src/app/editor/editor-home/editor-home.component.html
+++ b/src/app/editor/editor-home/editor-home.component.html
@@ -1,0 +1,15 @@
+<nav mat-tab-nav-bar>
+  <a
+    mat-tab-link
+    *ngFor="let link of navLinks"
+    [routerLink]="link.path"
+    [routerLinkActiveOptions]="{ exact: true }"
+    routerLinkActive
+    #rla="routerLinkActive"
+    [active]="rla.isActive"
+  >
+    {{ link.label }}
+  </a>
+</nav>
+
+<router-outlet> </router-outlet>

--- a/src/app/editor/editor-home/editor-home.component.spec.ts
+++ b/src/app/editor/editor-home/editor-home.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditorHomeComponent } from './editor-home.component';
+
+describe('EditorHomeComponent', () => {
+  let component: EditorHomeComponent;
+  let fixture: ComponentFixture<EditorHomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorHomeComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorHomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor/editor-home/editor-home.component.ts
+++ b/src/app/editor/editor-home/editor-home.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-editor-home',
+  templateUrl: './editor-home.component.html',
+  styleUrls: ['./editor-home.component.scss'],
+})
+export class EditorHomeComponent implements OnInit {
+  navLinks = [
+    {
+      label: '記事作成',
+      path: 'editor',
+    },
+    {
+      label: '記事一覧',
+      path: 'editor-article-list',
+    },
+    {
+      label: 'メンバー管理',
+      path: 'editor-member-list',
+    },
+  ];
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/editor/editor-member-list/editor-member-list.component.html
+++ b/src/app/editor/editor-member-list/editor-member-list.component.html
@@ -1,0 +1,1 @@
+<p>editor-member-list works!</p>

--- a/src/app/editor/editor-member-list/editor-member-list.component.spec.ts
+++ b/src/app/editor/editor-member-list/editor-member-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditorMemberListComponent } from './editor-member-list.component';
+
+describe('EditorMemberListComponent', () => {
+  let component: EditorMemberListComponent;
+  let fixture: ComponentFixture<EditorMemberListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorMemberListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorMemberListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor/editor-member-list/editor-member-list.component.ts
+++ b/src/app/editor/editor-member-list/editor-member-list.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-editor-member-list',
+  templateUrl: './editor-member-list.component.html',
+  styleUrls: ['./editor-member-list.component.scss'],
+})
+export class EditorMemberListComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/editor/editor-routing.module.ts
+++ b/src/app/editor/editor-routing.module.ts
@@ -1,12 +1,28 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { EditorComponent } from './editor/editor.component';
+import { EditorArticleListComponent } from './editor-article-list/editor-article-list.component';
+import { EditorMemberListComponent } from './editor-member-list/editor-member-list.component';
+import { EditorHomeComponent } from './editor-home/editor-home.component';
 
 const routes: Routes = [
   {
     path: '',
-    pathMatch: 'full',
-    component: EditorComponent,
+    component: EditorHomeComponent,
+    children: [
+      {
+        path: 'editor',
+        component: EditorComponent,
+      },
+      {
+        path: 'editor-article-list',
+        component: EditorArticleListComponent,
+      },
+      {
+        path: 'editor-member-list',
+        component: EditorMemberListComponent,
+      },
+    ],
   },
 ];
 

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -17,6 +17,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { EditorArticleListComponent } from './editor-article-list/editor-article-list.component';
 import { EditorMemberListComponent } from './editor-member-list/editor-member-list.component';
 import { EditorHomeComponent } from './editor-home/editor-home.component';
+import { MatPaginatorModule } from '@angular/material/paginator';
 
 @NgModule({
   declarations: [
@@ -40,6 +41,7 @@ import { EditorHomeComponent } from './editor-home/editor-home.component';
     MatTabsModule,
     MatTableModule,
     MatRadioModule,
+    MatPaginatorModule,
   ],
 })
 export class EditorModule {}

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -14,9 +14,17 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTableModule } from '@angular/material/table';
 import { MatRadioModule } from '@angular/material/radio';
+import { EditorArticleListComponent } from './editor-article-list/editor-article-list.component';
+import { EditorMemberListComponent } from './editor-member-list/editor-member-list.component';
+import { EditorHomeComponent } from './editor-home/editor-home.component';
 
 @NgModule({
-  declarations: [EditorComponent],
+  declarations: [
+    EditorComponent,
+    EditorArticleListComponent,
+    EditorMemberListComponent,
+    EditorHomeComponent,
+  ],
   imports: [
     CommonModule,
     EditorRoutingModule,

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -18,6 +18,7 @@ import { EditorArticleListComponent } from './editor-article-list/editor-article
 import { EditorMemberListComponent } from './editor-member-list/editor-member-list.component';
 import { EditorHomeComponent } from './editor-home/editor-home.component';
 import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   declarations: [
@@ -42,6 +43,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
     MatTableModule,
     MatRadioModule,
     MatPaginatorModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class EditorModule {}

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -1,230 +1,224 @@
-<mat-tab-group animationDuration="0ms">
-  <mat-tab label="記事一覧"></mat-tab>
-  <mat-tab label="記事作成">
-    <form [formGroup]="form" (ngSubmit)="submit()">
-      <div class="edit-column">
-        <div class="edit-column__left">
-          <h2>記事タイトル</h2>
-          <mat-form-field appearance="outline">
-            <input matInput formControlName="title" #title required />
-            <mat-hint align="end">{{ title.value.length }} / 150文字</mat-hint>
-          </mat-form-field>
-          <mat-divider></mat-divider>
+<form [formGroup]="form" (ngSubmit)="submit()">
+  <div class="edit-column">
+    <div class="edit-column__left">
+      <h2>記事タイトル</h2>
+      <mat-form-field appearance="outline">
+        <input matInput formControlName="title" #title required />
+        <mat-hint align="end">{{ title.value.length }} / 150文字</mat-hint>
+      </mat-form-field>
+      <mat-divider></mat-divider>
 
-          <h2>メイン画像</h2>
-          <div class="main-img">
-            <img *ngIf="srcs?.thumbnailURL" [src]="srcs.thumbnailURL" alt="" />
-            <p class="note" *ngIf="!srcs.thumbnailURL">
-              ※ 1280px x 720px
-            </p>
-            <input
-              type="file"
-              style="display: none;"
-              #thumbnailInput
-              (change)="setImage($event, 'thumbnailURL')"
-              accept=".png, .img, .jpeg"
-            />
-            <button
-              type="button"
-              (click)="thumbnailInput.click()"
-              mat-mini-fab
-              color=""
-              class="img-button"
-            >
-              <mat-icon>add_photo_alternate</mat-icon>
-            </button>
-            <p class="file-name" *ngIf="!srcs.thumbnailURL">
-              ファイルが選択されていません
-            </p>
-          </div>
-          <mat-divider></mat-divider>
-
-          <h2>サービス名</h2>
-          <mat-form-field appearance="outline">
-            <input matInput formControlName="name" #name required />
-            <mat-hint align="end">{{ name.value.length }} / 50文字</mat-hint>
-          </mat-form-field>
-
-          <h2>サービスロゴ</h2>
-          <div class="logo-img">
-            <img *ngIf="srcs?.logo" [src]="srcs.logo" alt="" />
-            <p class="note" *ngIf="!srcs.logo">
-              ※ 800px x 800px
-            </p>
-            <input
-              type="file"
-              style="display: none;"
-              #logoInput
-              (change)="setImage($event, 'logo')"
-              accept=".png, .img, .jpeg"
-            />
-            <button
-              type="button"
-              (click)="logoInput.click()"
-              mat-mini-fab
-              color=""
-              class="img-button"
-            >
-              <mat-icon>add_photo_alternate</mat-icon>
-            </button>
-            <p class="file-name" *ngIf="!srcs.logo">
-              ファイルが選択されていません
-            </p>
-          </div>
-
-          <h2>タイプ</h2>
-          <mat-radio-group
-            color="primary"
-            aria-label="Select an option"
-            formControlName="type"
-          >
-            <mat-radio-button value="school">スクール</mat-radio-button>
-            <mat-radio-button value="salon">オンラインサロン</mat-radio-button>
-          </mat-radio-group>
-
-          <h2>カテゴリー</h2>
-          <mat-form-field>
-            <mat-select formControlName="categorys">
-              <mat-option
-                *ngFor="let category of categoryGroup"
-                [value]="category.value"
-              >
-                {{ category.viewValue }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-divider></mat-divider>
-        </div>
-
-        <div class="edit-column__center">
-          <h2>サービスの特徴</h2>
-          <h3>イメージ画像1</h3>
-          <div class="sub-img">
-            <img *ngIf="srcs?.image1" [src]="srcs.image1" alt="" />
-            <p class="note" *ngIf="!srcs.image1">
-              ※ 800px x 800px
-            </p>
-            <input
-              type="file"
-              style="display: none;"
-              #image1Input
-              (change)="setImage($event, 'image1')"
-              accept=".png, .img, .jpeg"
-            />
-            <button
-              type="button"
-              (click)="image1Input.click()"
-              mat-mini-fab
-              color=""
-              class="img-button"
-            >
-              <mat-icon>add_photo_alternate</mat-icon>
-            </button>
-            <p class="file-name" *ngIf="!srcs.image1">
-              ファイルが選択されていません
-            </p>
-          </div>
-
-          <h3>タイトル</h3>
-          <mat-form-field appearance="outline">
-            <input matInput formControlName="featureTitle1" required />
-            <mat-hint align="end"
-              >{{ featureTitle1.value.length }} / 50文字</mat-hint
-            >
-          </mat-form-field>
-
-          <mat-form-field appearance="outline" class="feature">
-            <textarea
-              matInput
-              formControlName="featureBody1"
-              matTextareaAutosize
-              [matAutosizeMinRows]="4"
-            ></textarea>
-            <mat-hint align="end"
-              >{{ featureBody1.value.length }} / 200文字</mat-hint
-            >
-          </mat-form-field>
-          <mat-divider></mat-divider>
-
-          <h3>イメージ画像2</h3>
-          <div class="sub-img">
-            <img *ngIf="srcs?.image2" [src]="srcs.image2" alt="" />
-            <p class="note" *ngIf="!srcs.image2">
-              ※ 800px x 800px
-            </p>
-            <input
-              type="file"
-              style="display: none;"
-              #image2Input
-              (change)="setImage($event, 'image2')"
-              accept=".png, .img, .jpeg"
-            />
-            <button
-              type="button"
-              (click)="image2Input.click()"
-              mat-mini-fab
-              color=""
-              class="img-button"
-            >
-              <mat-icon>add_photo_alternate</mat-icon>
-            </button>
-            <p class="file-name" *ngIf="!srcs.image2">
-              ファイルが選択されていません
-            </p>
-          </div>
-
-          <h3>タイトル</h3>
-          <mat-form-field appearance="outline">
-            <input matInput formControlName="featureTitle2" required />
-            <mat-hint align="end"
-              >{{ featureTitle2.value.length }} / 50文字</mat-hint
-            >
-          </mat-form-field>
-
-          <mat-form-field appearance="outline" class="feature">
-            <textarea
-              matInput
-              formControlName="featureBody2"
-              matTextareaAutosize
-              [matAutosizeMinRows]="4"
-            ></textarea>
-            <mat-hint align="end"
-              >{{ featureBody2.value.length }} / 200文字</mat-hint
-            >
-          </mat-form-field>
-          <mat-divider></mat-divider>
-        </div>
-
-        <div class="edit-column__right">
-          <h2>プラン</h2>
-          <mat-form-field appearance="outline" class="feature">
-            <textarea
-              matInput
-              formControlName="plan"
-              #plan
-              matTextareaAutosize
-              [matAutosizeMinRows]="10"
-            ></textarea>
-            <mat-hint align="end">{{ plan.value.length }} / 400文字</mat-hint>
-          </mat-form-field>
-
-          <h2>サービスURL</h2>
-          <mat-form-field appearance="outline">
-            <input matInput formControlName="serviceURL" required />
-          </mat-form-field>
-          <mat-slide-toggle color="primary">非公開 / 公開</mat-slide-toggle>
-
-          <button
-            mat-fab
-            color="primary"
-            class="submit-button"
-            [disabled]="form.invalid"
-          >
-            GO
-          </button>
-        </div>
+      <h2>メイン画像</h2>
+      <div class="main-img">
+        <img *ngIf="srcs?.thumbnailURL" [src]="srcs.thumbnailURL" alt="" />
+        <p class="note" *ngIf="!srcs.thumbnailURL">
+          ※ 1280px x 720px
+        </p>
+        <input
+          type="file"
+          style="display: none;"
+          #thumbnailInput
+          (change)="setImage($event, 'thumbnailURL')"
+          accept=".png, .img, .jpeg"
+        />
+        <button
+          type="button"
+          (click)="thumbnailInput.click()"
+          mat-mini-fab
+          color=""
+          class="img-button"
+        >
+          <mat-icon>add_photo_alternate</mat-icon>
+        </button>
+        <p class="file-name" *ngIf="!srcs.thumbnailURL">
+          ファイルが選択されていません
+        </p>
       </div>
-    </form>
-  </mat-tab>
-  <mat-tab label="メンバー管理"> </mat-tab>
-</mat-tab-group>
+      <mat-divider></mat-divider>
+
+      <h2>サービス名</h2>
+      <mat-form-field appearance="outline">
+        <input matInput formControlName="name" #name required />
+        <mat-hint align="end">{{ name.value.length }} / 50文字</mat-hint>
+      </mat-form-field>
+
+      <h2>サービスロゴ</h2>
+      <div class="logo-img">
+        <img *ngIf="srcs?.logo" [src]="srcs.logo" alt="" />
+        <p class="note" *ngIf="!srcs.logo">
+          ※ 800px x 800px
+        </p>
+        <input
+          type="file"
+          style="display: none;"
+          #logoInput
+          (change)="setImage($event, 'logo')"
+          accept=".png, .img, .jpeg"
+        />
+        <button
+          type="button"
+          (click)="logoInput.click()"
+          mat-mini-fab
+          color=""
+          class="img-button"
+        >
+          <mat-icon>add_photo_alternate</mat-icon>
+        </button>
+        <p class="file-name" *ngIf="!srcs.logo">
+          ファイルが選択されていません
+        </p>
+      </div>
+
+      <h2>タイプ</h2>
+      <mat-radio-group
+        color="primary"
+        aria-label="Select an option"
+        formControlName="type"
+      >
+        <mat-radio-button value="school">スクール</mat-radio-button>
+        <mat-radio-button value="salon">オンラインサロン</mat-radio-button>
+      </mat-radio-group>
+
+      <h2>カテゴリー</h2>
+      <mat-form-field>
+        <mat-select formControlName="categorys">
+          <mat-option
+            *ngFor="let category of categoryGroup"
+            [value]="category.value"
+          >
+            {{ category.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-divider></mat-divider>
+    </div>
+
+    <div class="edit-column__center">
+      <h2>サービスの特徴</h2>
+      <h3>イメージ画像1</h3>
+      <div class="sub-img">
+        <img *ngIf="srcs?.image1" [src]="srcs.image1" alt="" />
+        <p class="note" *ngIf="!srcs.image1">
+          ※ 800px x 800px
+        </p>
+        <input
+          type="file"
+          style="display: none;"
+          #image1Input
+          (change)="setImage($event, 'image1')"
+          accept=".png, .img, .jpeg"
+        />
+        <button
+          type="button"
+          (click)="image1Input.click()"
+          mat-mini-fab
+          color=""
+          class="img-button"
+        >
+          <mat-icon>add_photo_alternate</mat-icon>
+        </button>
+        <p class="file-name" *ngIf="!srcs.image1">
+          ファイルが選択されていません
+        </p>
+      </div>
+
+      <h3>タイトル</h3>
+      <mat-form-field appearance="outline">
+        <input matInput formControlName="featureTitle1" required />
+        <mat-hint align="end"
+          >{{ featureTitle1.value.length }} / 50文字</mat-hint
+        >
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="feature">
+        <textarea
+          matInput
+          formControlName="featureBody1"
+          matTextareaAutosize
+          [matAutosizeMinRows]="4"
+        ></textarea>
+        <mat-hint align="end"
+          >{{ featureBody1.value.length }} / 200文字</mat-hint
+        >
+      </mat-form-field>
+      <mat-divider></mat-divider>
+
+      <h3>イメージ画像2</h3>
+      <div class="sub-img">
+        <img *ngIf="srcs?.image2" [src]="srcs.image2" alt="" />
+        <p class="note" *ngIf="!srcs.image2">
+          ※ 800px x 800px
+        </p>
+        <input
+          type="file"
+          style="display: none;"
+          #image2Input
+          (change)="setImage($event, 'image2')"
+          accept=".png, .img, .jpeg"
+        />
+        <button
+          type="button"
+          (click)="image2Input.click()"
+          mat-mini-fab
+          color=""
+          class="img-button"
+        >
+          <mat-icon>add_photo_alternate</mat-icon>
+        </button>
+        <p class="file-name" *ngIf="!srcs.image2">
+          ファイルが選択されていません
+        </p>
+      </div>
+
+      <h3>タイトル</h3>
+      <mat-form-field appearance="outline">
+        <input matInput formControlName="featureTitle2" required />
+        <mat-hint align="end"
+          >{{ featureTitle2.value.length }} / 50文字</mat-hint
+        >
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="feature">
+        <textarea
+          matInput
+          formControlName="featureBody2"
+          matTextareaAutosize
+          [matAutosizeMinRows]="4"
+        ></textarea>
+        <mat-hint align="end"
+          >{{ featureBody2.value.length }} / 200文字</mat-hint
+        >
+      </mat-form-field>
+      <mat-divider></mat-divider>
+    </div>
+
+    <div class="edit-column__right">
+      <h2>プラン</h2>
+      <mat-form-field appearance="outline" class="feature">
+        <textarea
+          matInput
+          formControlName="plan"
+          #plan
+          matTextareaAutosize
+          [matAutosizeMinRows]="10"
+        ></textarea>
+        <mat-hint align="end">{{ plan.value.length }} / 400文字</mat-hint>
+      </mat-form-field>
+
+      <h2>サービスURL</h2>
+      <mat-form-field appearance="outline">
+        <input matInput formControlName="serviceURL" required />
+      </mat-form-field>
+      <mat-slide-toggle color="primary">非公開 / 公開</mat-slide-toggle>
+
+      <button
+        mat-fab
+        color="primary"
+        class="submit-button"
+        [disabled]="form.invalid"
+      >
+        GO
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/app/services/loading.service.spec.ts
+++ b/src/app/services/loading.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoadingService } from './loading.service';
+
+describe('LoadingService', () => {
+  let service: LoadingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoadingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/loading.service.ts
+++ b/src/app/services/loading.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoadingService {
+  loadingSource = new Subject();
+  loading$ = this.loadingSource.asObservable();
+
+  constructor() {}
+
+  toggleLoading(status: boolean) {
+    this.loadingSource.next(status);
+  }
+}


### PR DESCRIPTION
## Detail

以下の内容を実装しました。
ご確認のほどよろしくお願いします。

- [x] 記事一覧画面追加
- [x] メンバー管理タブ追加
- [x] editor-home画面追加
- [x] 記事読み込みのローディングUI追加

## Image

![image](https://user-images.githubusercontent.com/60227737/84613179-abc51400-aefd-11ea-8919-447a109c061d.png)

## Next

- [ ] 記事の更新機能追加 #39 